### PR TITLE
Fix library path problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Notes on using TCA9548A I2C Multiplexer:
 ### Installation
 ```bash
 # Python2
-pip2 install git+https://github.com/grantramsay/VL53L0X_rasp_python.git
+pip2 install git+https://github.com/w4-jonghoon/VL53L0X_rasp_python.git
 # Python3
-pip3 install git+https://github.com/grantramsay/VL53L0X_rasp_python.git
+pip3 install git+https://github.com/w4-jonghoon/VL53L0X_rasp_python.git
 ```
 
 ### Compilation
@@ -54,7 +54,7 @@ sudo apt-get install build-essential python-dev
 Then use following commands to clone the repository and compile:
 ```bash
 cd your_git_directory
-git clone https://github.com/johnbryanmoore/VL53L0X_rasp_python.git
+git clone https://github.com/w4-jonghoon/VL53L0X_rasp_python.git
 cd VL53L0X_rasp_python
 make
 ```

--- a/python/VL53L0X.py
+++ b/python/VL53L0X.py
@@ -21,9 +21,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from ctypes import CDLL, CFUNCTYPE, POINTER, c_int, c_uint, pointer, c_ubyte, c_uint8, c_uint32
-import smbus2 as smbus
+import os
+
+from ctypes import (CDLL, CFUNCTYPE, POINTER,
+                    c_int, c_uint, pointer, c_ubyte, c_uint8, c_uint32)
 import site
+import smbus2 as smbus
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class Vl53l0xError(RuntimeError):
@@ -66,7 +71,8 @@ _I2C_READ_FUNC = CFUNCTYPE(c_int, c_ubyte, c_ubyte, POINTER(c_ubyte), c_ubyte)
 _I2C_WRITE_FUNC = CFUNCTYPE(c_int, c_ubyte, c_ubyte, POINTER(c_ubyte), c_ubyte)
 
 # Load VL53L0X shared lib
-_POSSIBLE_LIBRARY_LOCATIONS = ['../bin'] + site.getsitepackages()
+_POSSIBLE_LIBRARY_LOCATIONS = ([os.path.join(ROOT_DIR, 'bin/')] +
+                               site.getsitepackages())
 for lib_location in _POSSIBLE_LIBRARY_LOCATIONS:
     try:
         _TOF_LIBRARY = CDLL(lib_location + "/vl53l0x_python.so")


### PR DESCRIPTION
When I execute the example code, there was "Could not find vl53l0x_python.so" error.

So, I fixed based on @Lucianovici  's patch (https://github.com/johnbryanmoore/VL53L0X_rasp_python/pull/12/commits/77d9a768692ddcf268928c1bd2767babbe20503c)

- Add dynamic absolute path to shared lib. 