### PR TITLE
Call VL53L0X.open() after GPIO goes HIGH

### DIFF
--- a/python/VL53L0X_multi_example.py
+++ b/python/VL53L0X_multi_example.py
@@ -49,19 +49,19 @@ time.sleep(0.50)
 # each.
 tof = VL53L0X.VL53L0X(i2c_address=0x2B)
 tof1 = VL53L0X.VL53L0X(i2c_address=0x2D)
-tof.open()
-tof1.open()
 
 # Set shutdown pin high for the first VL53L0X then 
 # call to start ranging 
 GPIO.output(sensor1_shutdown, GPIO.HIGH)
 time.sleep(0.50)
+tof.open()
 tof.start_ranging(VL53L0X.Vl53l0xAccuracyMode.BETTER)
 
 # Set shutdown pin high for the second VL53L0X then 
 # call to start ranging 
 GPIO.output(sensor2_shutdown, GPIO.HIGH)
 time.sleep(0.50)
+tof1.open()
 tof1.start_ranging(VL53L0X.Vl53l0xAccuracyMode.BETTER)
 
 timing = tof.get_timing()


### PR DESCRIPTION
There was an issue to execute `VL53L0X_multi_example.py`.
> pi@raspberrypi:~/jseo/VL53L0X_rasp_python/python $ python VL53L0X_multi_example.py
VL53L0X Start Ranging Address 0x2B
>
>Setting I2C Address to 0x2B
Call of VL53L0X_SetAddress
API Status: -20 : Control Interface Error
VL53L0X Start Ranging Address 0x2D
>
>Setting I2C Address to 0x2D
Call of VL53L0X_SetAddress
API Status: -20 : Control Interface Error
VL53L0X_BETTER_ACCURACY_MODE
API Status: 0 : No Error
VL53L0X_BETTER_ACCURACY_MODE
Set Accuracy
API Status: -20 : Control Interface Error
Timing 20 ms

I figured out that is because calling `VL53L0X.open()` before GPIO goes High (`GPIO.output(sensor[12]_shutdown, GPIO.HIGH)`.
The problem - `Control Interface Error` was occurred while writing to i2c bus in `VL53L0X_SetDeviceAddress()` in `vl53l0x_api.c`.
I'm not sure it is safe to make GPIO high before the calling the function(`VL53L0X.open()`), but it is working.
Please review change and pull the patch.